### PR TITLE
Fix #569: Dataset name is not centered on navbar and is not responsively-designed

### DIFF
--- a/R/navbar.R
+++ b/R/navbar.R
@@ -11,11 +11,12 @@
 #' @export 
 navbar <- function(
   title,
+  center,
   ...
 ) {
   if(missing(title))
     stop("Missing `title`")
-
+ 
   tags$nav(
     class = "navbar navbar-light bg-white mb-0 pb-0",
     div(
@@ -37,7 +38,15 @@ navbar <- function(
         )
       ),
       div(
-        class = "collapse navbar-collapse",
+        class = "collapse navbar-collapse justify-content-center",
+        id = "navbarCenterContent",
+        tags$ul(
+          class = "navbar-nav mb-2 mb-lg-0",
+          center
+        )
+      ),
+      div(
+        class = "collapse navbar-collapse flex-grow-0",
         id = "navbarContent",
         tags$ul(
           class = "navbar-nav ms-auto mb-2 mb-lg-0",


### PR DESCRIPTION
## Description

Create a center div argument for the `navbar` function. 

Before we just had a title + an array of divs that were placed on the right. To center the dataset name a hacky trick was performed from OPG. This hack worked ~ok on most screens but was not responsive or accurate. Now we place a center div between the title and all the elements on the right.

This PR should be merged before the one in OPG that closes the issue. 

![image](https://github.com/bigomics/bigdash/assets/10220503/23ef2069-e76a-49ea-a337-0f4d3aab421f)

![image](https://github.com/bigomics/bigdash/assets/10220503/0890c515-c03f-49c1-b8d4-903b50d2307f)

![image](https://github.com/bigomics/bigdash/assets/10220503/63d471f1-0424-4cb4-8cf0-14547a24df42)

![image](https://github.com/bigomics/bigdash/assets/10220503/609f2c4a-020b-42a1-96c4-eaea03015ff8)

